### PR TITLE
Update video quality

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function takeScreenshot(videoUrl, timestampInSeconds, outputPath, filename
             throw new Error('Requested timestamp is beyond the video duration.');
         }
         const timeFormat = secondsToTimeFormat(timestampInSeconds)
-        const videoStream = ytdl(videoUrl, { quality: 'highest' });
+        const videoStream = ytdl(videoUrl, { quality: 'highestvideo' });
         await screenshot(videoStream, timeFormat, outputPath, filename);
     } catch (error) {
         throw error;


### PR DESCRIPTION
I've update the ytdl quality property to 'highestvideo' as this will retrieve the highest overall video quality as 'highest' looks for the best video + audio combo but in our case we don't need audio with the video.

Below are some example ouputs:

'highestvideo'
![sample](https://github.com/anuragphadke/youtube-screenshot/assets/1872377/ef0649f7-222b-4cb1-aa42-4f23ace9a329)

'highest'
![sample](https://github.com/anuragphadke/youtube-screenshot/assets/1872377/dedeeec0-39c0-4291-8793-93a298ffa38e)
